### PR TITLE
Remove dead code

### DIFF
--- a/kafka-cluster/kafka-cluster-start.sh
+++ b/kafka-cluster/kafka-cluster-start.sh
@@ -8,8 +8,6 @@ fi
 
 cd $KAFKA_HOME
 
-PIDS=
-
 stop_all() {
     trap "exit 0" HUP INT QUIT TERM
     bin/kafka-server-stop.sh


### PR DESCRIPTION
In kafka-cluster/kafka-cluster-start.sh: variable `PIDS' is created but never used